### PR TITLE
Minor bug fix and manual focus control added.

### DIFF
--- a/CameraStreamer.cs
+++ b/CameraStreamer.cs
@@ -18,7 +18,7 @@ public class HttpCameraServer
     private TcpListener? listener;
     private Thread? listenerThread;
 
-    public HttpCameraServer(int webPort, string deviceName, int resX = 0, int resY = 0)
+    public HttpCameraServer(int webPort, string deviceName, int resX = 0, int resY = 0, int focusValue = 0)
     {
         videoDevices = new FilterInfoCollection(FilterCategory.VideoInputDevice);
         this.Port = webPort;
@@ -58,6 +58,11 @@ public class HttpCameraServer
         Console.WriteLine($"Using device: {selectedDevice.Name}\n");
 
         videoSource = new VideoCaptureDevice(selectedDevice.MonikerString);
+        videoSource.SetCameraProperty(CameraControlProperty.Focus, 120, CameraControlFlags.Auto);
+        if(focusValue > 0)
+        {
+          videoSource.SetCameraProperty(CameraControlProperty.Focus, focusValue, CameraControlFlags.Manual);
+        }
         videoSource.NewFrame += new NewFrameEventHandler(video_NewFrame);
 
         Console.WriteLine("Available frame sizes:");

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@
 string videoDeviceName = "";
 int resolutionWidth = 0;
 int resolutionHeight = 0;
+int focusValue = 0;
 int webPort = 8080;
 
 var version = Assembly.GetExecutingAssembly().GetName().Version;
@@ -11,7 +12,7 @@ Console.WriteLine($"WebCamServer {version}\n");
 if ((args.Length == 1) && ((args[0] == "/?") || (args[0] == "--help")))
 {
     Console.WriteLine("Usage:");
-    Console.WriteLine("WebCamServer --device=<device name> --width=<resWidth> --heigth=<resHeigth>");
+    Console.WriteLine("WebCamServer --device=<device name> --width=<resWidth> --heigth=<resHeigth> --focus=<0-255> --port=<port>");
     return;
 }
 
@@ -30,11 +31,15 @@ foreach (var arg in args)
     {
         resolutionHeight = int.Parse(arg.Split('=')[1]);
     }
+    else if (arg.StartsWith("--focus="))
+    {
+        focusValue = Math.Min(250,Math.Max(0,int.Parse(arg.Split('=')[1])));
+    }
     else if (arg.StartsWith("--port="))
     {
         webPort = int.Parse(arg.Split('=')[1]);
     }
 }
 
-var server = new HttpCameraServer(webPort, videoDeviceName, resolutionWidth, resolutionHeight);
+var server = new HttpCameraServer(webPort, videoDeviceName, resolutionWidth, resolutionHeight, focusValue);
 server.Start();

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ shows the help information.
 
 ```
 Usage:
-WebCamServer --device=<device name> --width=<resWidth> --heigth=<resHeigth> --port=<port>
+WebCamServer --device=<device name> --width=<resWidth> --heigth=<resHeigth> --port=<port> --focus=<0-250>
 ```
 
 Device can be a part of the device name (case insensitive).


### PR DESCRIPTION
After starting the server it would not start the VideoCaptureDevice until /stream.jpg was hit, so /current.jpg would not work.

Fix added by allowing ServeCurrentImage to also call VideoCaptureDevice.Start.

Added argument to manually control camera focus.